### PR TITLE
chore: Add cache directories to Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ deploy:
   github_token: $GITHUB_DEPLOY_TOKEN
   local_dir: dist
   skip_cleanup: true
+cache:
+  directories:
+    - .linaria-cache
+    - .sticker-pack-cache


### PR DESCRIPTION
This update adds the Linaria and sticker pack directories to Travis' cache, which should allow builds to run faster and require fewer requests to the Signal API.