### PR TITLE
chore: Fix warnings in Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 language: node_js
 node_js:
   - 12
@@ -9,9 +10,9 @@ deploy:
   on:
     branch: master
   provider: pages
-  github_token: $GITHUB_DEPLOY_TOKEN
+  token: $GITHUB_DEPLOY_TOKEN
   local_dir: dist
-  skip_cleanup: true
+  cleanup: false
 cache:
   directories:
     - .linaria-cache


### PR DESCRIPTION
This update addresses the following warnings in `.travis.yml`:

<img width="1015" alt="Screen Shot 2020-02-01 at 6 38 18 PM" src="https://user-images.githubusercontent.com/441546/73601634-452cf400-4522-11ea-9948-a3dfe833cdda.png">
