### PR TITLE
feat: add Original label

### DIFF
--- a/src/components/contribute/Contribute.tsx
+++ b/src/components/contribute/Contribute.tsx
@@ -55,6 +55,7 @@ export interface FormValues {
   source: string;
   tags: string;
   isNsfw?: 'true' | 'false';
+  isOriginal?: 'true' | 'false';
 }
 
 
@@ -77,7 +78,8 @@ const initialValues: FormValues = {
   signalArtUrl: '',
   source: '',
   tags: '',
-  isNsfw: undefined
+  isNsfw: undefined,
+  isOriginal: undefined
 };
 
 /**
@@ -119,6 +121,12 @@ const validators = {
   },
   isNsfw: (isNsfw?: boolean) => {
     if (isNsfw === undefined) {
+      return 'This field is required.';
+    }
+  }
+  ,
+  isOriginal: (isOriginal?: boolean) => {
+    if (isOriginal === undefined) {
       return 'This field is required.';
     }
   }
@@ -172,7 +180,8 @@ const ContributeComponent: React.FunctionComponent = () => {
         key: packKey,
         source: values.source,
         tags,
-        nsfw: values.isNsfw === 'true' ? true : false
+        nsfw: values.isNsfw === 'true' ? true : false,
+        original: values.isOriginal === 'true' ? true : false
       }
     }, {
       indent: 2
@@ -312,6 +321,50 @@ const ContributeComponent: React.FunctionComponent = () => {
                     </div>
                     <div className="invalid-feedback">
                       <ErrorMessage name="isNsfw" />&nbsp;
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* [Field] Original */}
+              <div className="form-group">
+                <div className="form-row">
+                  <label className={cx('col-12', 'mb-2', errors.isOriginal && 'text-danger')}>
+                   Is your pack original? Did the author of the pack draw it exclusively for Signal, from original artworks?
+                  </label>
+                </div>
+                <div className="form-row">
+                  <div className="col-12 mb-1">
+                    <div className="custom-control custom-radio">
+                      <Field
+                        type="radio"
+                        id="is-original-true"
+                        name="isOriginal"
+                        validate={validators.isOriginal}
+                        className={cx('custom-control-input', errors.isOriginal && 'is-invalid')}
+                        value="true"
+                        checked={values.isOriginal === 'true'}
+                      />
+                      <label className="custom-control-label" htmlFor="is-original-true">
+                        Yes
+                      </label>
+                    </div>
+                  </div>
+                  <div className="col-12 mb-1">
+                    <div className="custom-control custom-radio">
+                      <Field
+                        type="radio"
+                        id="is-original-false"
+                        name="isOriginal"
+                        validate={validators.isOriginal}
+                        className={cx('custom-control-input', errors.isOriginal && 'is-invalid')}
+                        value="false"
+                        checked={values.isOriginal === 'false'}
+                      />
+                      <label className="custom-control-label" htmlFor="is-original-false">No</label>
+                    </div>
+                    <div className="invalid-feedback">
+                      <ErrorMessage name="isOriginal" />&nbsp;
                     </div>
                   </div>
                 </div>

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -11,9 +11,7 @@ const HomeComponent: React.FunctionComponent = () => {
         <div className="col-12">
           <p className="my-4 py-lg-2">
             Welcome to Signal Stickers, the unofficial directory for Signal sticker
-            packs. You can filter packs by title, author, or tags.
-          </p>
-          <p>
+            packs. You can filter packs by title, author, or tags.<br/>
             Follow <a href="https://twitter.com/signalstickers" rel="noreferrer" target="_blank" title="Twitter feed">@signalstickers</a> to
             stay tuned for new packs!
             </p>

--- a/src/components/home/StickerPackPreviewCard.tsx
+++ b/src/components/home/StickerPackPreviewCard.tsx
@@ -17,9 +17,25 @@ export interface Props {
 
 // ----- Styles ----------------------------------------------------------------
 
-const StickerPackPreviewCard = styled.div<React.ComponentProps<'div'> & {nsfw?: boolean}>`
+const StickerPackPreviewCard = styled.div<React.ComponentProps<'div'> & {nsfw?: boolean} & {original?: boolean}>`
   text-align: center;
   transition: box-shadow 0.15s ease-in-out;
+  overflow: hidden;
+
+  &::after{
+    content: 'Original';
+    top: 13px;
+    left: O;
+    display: ${props => props.original ? 'block' : 'none'};
+    background-color: #3a76f0;
+    position: absolute;
+    padding: 3px 6px 3px 3px;
+    box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
+    color: white;
+    font-size: 12px;
+    border-bottom-right-radius: 4px;
+    border-top-right-radius: 4px;
+  }
 
   & .card-img-top {
     height: 72px;
@@ -98,7 +114,7 @@ const StickerPackPreviewCardComponent: React.FunctionComponent<Props> = props =>
   const title = [manifest.title, meta.nsfw && ' (NSFW)'].filter(Boolean).join('');
 
   return (
-    <StickerPackPreviewCard className="card" nsfw={meta.nsfw} aria-label={title}>
+    <StickerPackPreviewCard className="card" original={meta.original} nsfw={meta.nsfw} aria-label={title}>
       {cover ? <img className="card-img-top" src={cover} /> : <div className="card-img-top"></div>}
       <div className="card-header">{title}</div>
     </StickerPackPreviewCard>

--- a/src/components/pack/StickerPackDetail.tsx
+++ b/src/components/pack/StickerPackDetail.tsx
@@ -62,6 +62,10 @@ const StickerPackDetail = styled.div`
     color: ${SIGNAL_BLUE};
   }
 
+  & .octicon-star {
+    color: gold;
+  }
+
   & .octicon-tag {
     color: ${SIGNAL_BLUE};
   }
@@ -213,6 +217,9 @@ const StickerPackDetailComponent: React.FunctionComponent = () => {
       {stickerPack.meta ? <div className="row mb-4">
         <div className="col-12 col-lg-6">
           <ul className="list-group">
+            {stickerPack.meta.original ? <li className="list-group-item text-wrap text-break">
+            <Octicon name="star" title="Original sticker pack" /> This pack has been created exclusively for Signal by the artist, from original artworks.
+            </li> : null}
             <li className="list-group-item text-wrap text-break">
               <Octicon name="globe" title="Source" />
               <div>

--- a/src/etc/types.ts
+++ b/src/etc/types.ts
@@ -12,6 +12,7 @@ export interface StickerPackYaml {
     source: string;
     tags: Array<string>;
     nsfw?: boolean;
+    original?: boolean;
   };
 }
 
@@ -25,6 +26,7 @@ export interface StickerPackMetadata {
   source?: string;
   tags?: Array<string>;
   nsfw?: boolean;
+  original?: boolean;
 }
 
 

--- a/stickers.yml
+++ b/stickers.yml
@@ -13,6 +13,7 @@ ae1d343accdec586fe19954a6be7aee9:
     - internet
     - freedom
   nsfw: false
+  original: true
 123f678abcef7a39c0e710c051c68ae8:
   key: 84e89503556fa3568485a89d113b70ff73a8822a6c9c5c524ba2c7428007551d
   source: ''
@@ -671,6 +672,7 @@ a76321b39a185872fc759a43a095e332:
   source: 'https://twitter.com/CFWeb/status/1209443173564649479'
   tags: []
   nsfw: false
+  original: true
 8969c957cbd6ae9d033a4f8d3935a16e:
   key: 9c3d2ca44339bca302cdf929e9741b2f7b12556a4dcc8ffabea215d732bbd0c1
   source: 'https://github.com/signalstickers/signalstickers/pull/21'
@@ -870,6 +872,7 @@ a27b2ee11656275c0f900026e1327541:
     - love
     - watercolor
   nsfw: false
+  original: true
 6c160a6938404e27085d04176e828acd:
   key: 33229429b66caff14b1d0c180a088797a97b0be11b4398be7ad220aa16b0b71e
   source: telegram
@@ -922,6 +925,7 @@ a6d9d827b714e5acf1e03a0dceb7a6f3:
     - meta
     - privacy
   nsfw: false
+  original: true
 ce83961e7bffdb0cfbc9b0c614252cdf:
   key: 10b2e91aa996bfdc05cd0950cc0967d454bd798068cfb1f26988fd7c5469bcee
   source: >-
@@ -931,6 +935,7 @@ ce83961e7bffdb0cfbc9b0c614252cdf:
     - flashes
     - tatoo
   nsfw: false
+  original: true
 61bc889ce8ed59fbf3022b25376db025:
   key: 6b3276230265aedbd34824f4b302c73cb0a9a298173df1aff6a06b3d5fd89088
   source: ''
@@ -943,6 +948,7 @@ ce83961e7bffdb0cfbc9b0c614252cdf:
   source: ''
   tags: []
   nsfw: false
+  original: true
 1e012d5b00201f6498bd2596aa351629:
   key: 9d3768e49927d02fa20b8ed87ca6fbd2bad21317349fbeeff9004c3575445956
   source: ''
@@ -985,6 +991,7 @@ ea94b9358b81f288a23a832b1f9f22f3:
     - marie curie
     - marie jackson
   nsfw: false
+  original: true
 9d7f92d41649e2fd3594ae1ae0001055:
   key: 0a2ec8c32491ff264941469be8179956d626081b2b576cb49cc1869bfa54e43a
   source: Saul O'Gorman
@@ -992,6 +999,7 @@ ea94b9358b81f288a23a832b1f9f22f3:
     - oc
     - kid art
   nsfw: false
+  original: true
 107acdd3185620e983d00440302be101:
   key: 799d95aadc54bb04370b07e2b65eaa1898f7cf61810a6eb49dc7526f96f77f66
   source: 'http://vkclub.su/en/stickers/elvis/'
@@ -18317,6 +18325,7 @@ a294c9cbd93c3c2e09f9c05f1339828a:
     - public transit
     - numtot
   nsfw: false
+  original: true
 a79608cb9d82a68c57e837d3943bf5d2:
   key: 8f76958903ae6506cbbdcad9183d50925fede880627e47e009953d504499d284
   source: ''
@@ -18326,6 +18335,7 @@ a79608cb9d82a68c57e837d3943bf5d2:
     - France
     - rhonexpress
   nsfw: false
+  original: true
 dc6c215c48f7ad6af90a0bb87448f2eb:
   key: 5aaaf51fa965b98ccbe0e986ca3dc11df2a5c4720c04723a7c28171ee5d429af
   source: ''
@@ -18338,6 +18348,7 @@ dc6c215c48f7ad6af90a0bb87448f2eb:
     - tram
     - baguette du fromage
   nsfw: false
+  original: true
 76f937beffd4760dafd77baff76ad09b:
   key: 39ed2a2acb4977bec214f028dcb4ad98775b3212dd5310705be87f4c9f162df4
   source: https://play.google.com/store/apps/details?id=com.whamusaurus.gamusticker (made by Gamusaur for WhatsApp)
@@ -18379,6 +18390,7 @@ c4d50001e190c19f1d7aabc1b83e4041:
   source: 'https://www.instagram.com/dark.art.cat/'
   tags: []
   nsfw: false
+  original: true
 6bfa006d7c5c6478c5f88e0080b2195d:
   key: 69f6ddd1db5057a9089f6aaf22b1aff58948915a1275da7fd6f76df726d8b77c
   source: ''
@@ -18399,6 +18411,7 @@ c4d50001e190c19f1d7aabc1b83e4041:
     - Motorcycle
     - bike
   nsfw: false
+  original: true
 6bdfc11c96f763965d5eb6b7abadea83:
   key: 1320504bedc7a334527bc3ba6609b2732132723db96e00ff68976b8f39bdf6ba
   source: WhatsApp
@@ -18508,12 +18521,14 @@ cca32f5b905208b7d0f1e17f23fdc185:
   tags:
     - Signal
   nsfw: false
+  original: true
 e61fa0867031597467ccc036cc65d403:
   key: 13ae7b1a7407318280e9b38c1261ded38e0e7138b9f964a6ccbb73e40f737a9b
   source: 'https://signal.org/blog/swoon/'
   tags:
     - Signal
   nsfw: false
+  original: true
 cbc5510880d023fdbb773649d41ba6ce:
   key: df210abdb5591436a6c30f3fb4748df038f214501b46610f5b18a655322c9ef8
   source: www.carmenland.com
@@ -18936,11 +18951,13 @@ e9f052fa6ccb45e8e58166912c048fe6:
   source: 'https://twitter.com/Fleak/status/1236962821134528513'
   tags: []
   nsfw: false
+  original: true
 076ff304f216d736e5450d30b6fd3b20:
   key: b09decd96695145e81551bdb1c58961a241414b0ad68fa6b332b5e2fb2fd9b9d
   source: 'https://twitter.com/Fleak/status/1236411738012123138'
   tags: []
   nsfw: false
+  original: true
 66cce81c1eb8a2f38813c00560bb3ed4:
   key: 7a81652acb8921ba92b43a7d029b581333d6a02e7bab5bfc8b5d97b8b75470af
   source: 'Riley, https://furaffinity.net/user/rileyy/'
@@ -18998,6 +19015,7 @@ b9976aeb8b2dfb1a8f1d16dbd82fe330:
   tags:
     - mermaid
   nsfw: false
+  original: true
 23cc6d83aab2ac59f7f443beb03506d6:
   key: cf44a9ffd8ebcdcf499dbd6a31f668a3b4cd9d551e507649a7157d50b2890002
   source: 'https://twitter.com/writeswrongs/status/1243107565069713410'
@@ -19007,11 +19025,13 @@ b9976aeb8b2dfb1a8f1d16dbd82fe330:
     - society
     - protest
   nsfw: false
+  original: true
 a084936b99af1f34e0a6b26b01198c50:
   key: 7a6530403168a608b6fba83238d7c25a4f39a28fa30dbb84a81ee2849a734afa
   source: 'https://twitter.com/writeswrongs/status/1243096866041917441'
   tags: []
   nsfw: false
+  original: true
 94787afd0f9bf5565a75ca8657b62e08:
   key: d94c5cc4eeff3aefd56131a9e2a6fd139ad9e3c21bf33b19bc79fe30e3210280
   source: 'https://telegram.me/addstickers/AnimeReactions'
@@ -19038,6 +19058,7 @@ d1db446eba2254e6957f8a1d65dd3384:
   tags:
     - organize
   nsfw: false
+  original: true
 50f4e13908a3cfb27cc19294bb8d3486:
   key: 1f1de968a6e794f9d43f8d6cbe658a0eae045e4bfc9f6428dd25d581f86b39a9
   source: 'https://twitter.com/jhthenerd/status/1241817896617160705'
@@ -19050,6 +19071,7 @@ d1db446eba2254e6957f8a1d65dd3384:
   source: 'https://twitter.com/writeswrongs/status/1244131639048859648'
   tags: []
   nsfw: false
+  original: true
 5ea292ba83bf9448b3489b35c8bdb49c:
   key: 9be0ec3714d3fa16b31df0bed9090bf4e908ac947d71be0d6afafd1296b7a2ac
   source: 'https://twitter.com/writeswrongs/status/1243096441175728128'
@@ -19059,6 +19081,7 @@ d1db446eba2254e6957f8a1d65dd3384:
     - coronavirus
     - stayhome
   nsfw: false
+  original: true
 8e21a5bde99182638d40c7d70c8c954d:
   key: fd4f26e2952fac93e8304713db4c493eb0b2247fe08b2385342db80e3471c8d5
   source: Romain Ricard
@@ -19068,4 +19091,3 @@ d1db446eba2254e6957f8a1d65dd3384:
     - coronavirus
     - stayhome
   nsfw: false
-

--- a/tests/stickers.spec.ts
+++ b/tests/stickers.spec.ts
@@ -26,6 +26,9 @@ const schema = {
         },
         nsfw: {
           type: 'boolean'
+        },
+        original: {
+          type: 'boolean'
         }
       },
       additionalProperties: false,


### PR DESCRIPTION
This feature adds a label to packs made exclusively for Signal.
Pack list:
![image](https://user-images.githubusercontent.com/7778898/77856241-21bab880-71f6-11ea-922b-5220a79c2ac7.png)
Pack details:
![image](https://user-images.githubusercontent.com/7778898/77856247-27b09980-71f6-11ea-83cd-3e4848b4078b.png)
Contribution:
![image](https://user-images.githubusercontent.com/7778898/77856253-2ed7a780-71f6-11ea-85d3-14ec5824762d.png)
