### PR TITLE
fix: Make spaces in tags field optional.

### DIFF
--- a/src/components/contribute/Contribute.tsx
+++ b/src/components/contribute/Contribute.tsx
@@ -69,7 +69,7 @@ const SIGNAL_ART_URL_PATTERN = /^https:\/\/signal.art\/addstickers\/#pack_id=([A
 /**
  * Regular expression used to validate lists of tags.
  */
-const TAGS_PATTERN = /^(?:([\w\d-_ ]+))+(?:, ([\w\d-_ ]+))*$/g;
+const TAGS_PATTERN = /^(?:([\w\d-_ ]+))+(?:, ?([\w\d-_ ]+))*$/g;
 
 /**
  * Initial values for the form.


### PR DESCRIPTION
Fixes https://github.com/signalstickers/signalstickers/issues/175.

Not sure why this only appears in Firefox. Perhaps there's a discrepancy between how Chrome / Firefox implement regular expressions. The updated regex is, however, "more correct" as it explicitly makes the space following a comma optional, which was the original intent.

Tested in Firefox 75.0.