### PR TITLE
Add Fox News Armed Protester stickerpack

### DIFF
--- a/stickers.yml
+++ b/stickers.yml
@@ -20505,3 +20505,11 @@ c507d6d3c4f259f0caedf3ec3c9f076b:
     - right to repair
   nsfw: false
   original: true
+1009f6100acdc0efac99d90b411bb47a:
+  key: 1b222088b2910166076c2abb5bb8606551a0e2a56afa0fb5326234290b9437c0
+  source: ''
+  nsfw: false
+  original: false
+  tags:
+    - Fox News
+    - Fake News


### PR DESCRIPTION
Based on [recent events](https://www.seattletimes.com/seattle-news/politics/fox-news-runs-digitally-altered-images-in-coverage-of-seattles-protests-capitol-hill-autonomous-zone/), a Fox News armed protester sticker pack to easily add an armed protester to any image.

https://signalstickers.com/pack/1009f6100acdc0efac99d90b411bb47a?key=1b222088b2910166076c2abb5bb8606551a0e2a56afa0fb5326234290b9437c0