### PR TITLE
Allow searching on the "animated" property.

### DIFF
--- a/src/components/about/About.tsx
+++ b/src/components/about/About.tsx
@@ -52,6 +52,12 @@ const SearchHelp = () => (
         term <Term>unicorn</Term> in <em>any</em> attribute:
       </p>
       <Example>author:Sindre tag:awesome unicorn</Example>
+      <p className="mb-4">
+        Finally, you can filter by metadata.
+        Supported metadata are <Attr>nsfw</Attr>, <Attr>original</Attr> and <Attr>animated</Attr>. For
+        example, to search for all animated pack not-NSFW:
+      </p>
+      <Example>nsfw:false animated:true</Example>
     </div>
   </div>
 );

--- a/src/contexts/StickersContext.tsx
+++ b/src/contexts/StickersContext.tsx
@@ -64,13 +64,14 @@ export const Provider = (props: PropsWithChildren<Record<string, unknown>>) => {
     // Create a searcher using our collection of sticker pack partials.
     setSearcher(SearchFactory({
       collection: stickerPacks,
-      identity: pack => pack.meta.id,
+      identity: R.path(['meta', 'id']),
       keys: {
         title: ['manifest', 'title'],
         author: ['manifest', 'author'],
         tag: ['meta', 'tags'],
         nsfw: ['meta', 'nsfw'],
-        original: ['meta', 'original']
+        original: ['meta', 'original'],
+        animated: ['meta', 'animated']
       }
     }));
   }, []);


### PR DESCRIPTION
## Allow searching on the `animated` property

This update will allow the user to filter packs according to their `animated` property (ex: `animated: true`). This will also let us construct links that can filter on this field using the query builder.