### PR TITLE
feat: Auto-detect image MIME types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13698,6 +13698,21 @@
         "queue": "6.0.1"
       }
     },
+    "image-type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-4.1.0.tgz",
+      "integrity": "sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==",
+      "requires": {
+        "file-type": "^10.10.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+          "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
+        }
+      }
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "debounce-fn": "^4.0.0",
     "formik": "^2.1.5",
     "fuse.js": "^6.4.1",
+    "image-type": "^4.1.0",
     "js-yaml": "^3.14.0",
     "linaria": "^1.3.3",
     "localforage": "^1.9.0",


### PR DESCRIPTION
## Auto-detect image MIME types

Some experimentation has revealed that Signal does not enforce a particular image format, which was previously assumed to be WebP. This update adds the ability for us to inspect the binary data of each sticker and use the correct MIME type when returning base-64 encoded strings.

Tested in Safari and Mobile Safari and everything seems to be working, including animated stickers. 🎉 