### PR TITLE
Update stickers.yml

### DIFF
--- a/stickers.yml
+++ b/stickers.yml
@@ -32,8 +32,12 @@ ae1d343accdec586fe19954a6be7aee9:
 186cbb983fd8613e2292692a6ba31557:
   key: 33cc80357a10a7a0b162158f63eb6e98034472e0288a245bd02d07818208f399
   source: ''
-  tags: []
+  tags:
+    - games
+    - Lucasarts
+    - Day of the Tentacle
   nsfw: false
+  original: true
 2745f59ea0444bffb1db0984cc0ae65c:
   key: d1f656151045c812ca41cf65a1267d70d313e19925417aaa0e609d5f8e81ea7e
   source: ''
@@ -252,8 +256,10 @@ dad4d585930de459ea69ad5364e6c1fe:
 dbbdcc8cea92b39ee5a04e882895fff4:
   key: 7e7b0d320114cfea3ee00bfb7df3a2c4e50dc7feb29046e36f92e82a4cf10905
   source: ''
-  tags: []
+  tags:
+    - sports
   nsfw: false
+  original: true
 dd2076d5fe7558526ca9ff99274fb802:
   key: a87550d8dba47bce27b1f61b9611d8370f362857603695ffab192d2ee7a2a163
   source: ''
@@ -716,8 +722,10 @@ b9b48c7cf2d813d8088d009cd54cf1fa:
   key: 5db678fd5bad89552f412b82d623ed034cdd25c85358f12e1872c00bf0c8a479
   source: ''
   tags:
-    - monkey island
+    - games
+    - Lucasarts
   nsfw: false
+  original: true
 2f977990cc97776e3507f1f8c8ffa1b9:
   key: 9ef33e78c237f9da414e8758af1fba810878ae34c03afea43b2035bcb2d5321a
   source: ''
@@ -990,8 +998,10 @@ eb503c662934a80e245f518e4890f09b:
   key: fa14bdcecaf21183334d164e9a7848b65cf925a409a4de5995c43d95808914a9
   source: ''
   tags:
-    - monkey island
+    - games
+    - Lucasarts
   nsfw: false
+  original: true
 ea94b9358b81f288a23a832b1f9f22f3:
   key: 93d170819a194e2efb02134f9dbcb9f3ba60ce45063e408c3a376caaa88711d9
   source: ''
@@ -21281,5 +21291,12 @@ d92d7acd7e220d5303e3c5b863779509:
   source: 'https://www.facebook.com/Werschafe/'
   tags:
     - sheep
+  nsfw: false
+  original: true
+233b2eb84d94cb6a834807c0e3f9c3a7:
+  key: f950381ba1f1c06afa282f972f8f57c8658b78c511d8669003f7b3826f95cb85
+  source: ''
+  tags:
+    - politician
   nsfw: false
   original: true


### PR DESCRIPTION
New sticker pack (Hugo Chavez):
https://signal.art/addstickers/#pack_id=233b2eb84d94cb6a834807c0e3f9c3a7&pack_key=f950381ba1f1c06afa282f972f8f57c8658b78c511d8669003f7b3826f95cb85

Mark older sticker sets  (Aikido_20191219, DOT_20191221, Monkey Island, Monkey Island - Pure) as Originals and add tags.