### PR TITLE
Add Dark Mode 🧛🏻‍♂️

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     require.resolve('@darkobits/ts-unified/dist/config/eslint-react')
   ],
   rules: {
-    'jsx-a11y/no-autofocus': 'off',
-    'no-console': 'off'
+    'no-console': 'off',
+    'no-confusing-arrow': 'off'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,9 +1040,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
-          "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
+          "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==",
           "dev": true
         },
         "@babel/template": {
@@ -2103,9 +2103,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
-          "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
+          "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==",
           "dev": true
         },
         "@babel/template": {
@@ -2362,9 +2362,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.0.tgz",
-      "integrity": "sha512-K0ioacsw8JgzDSPpUiGWokMvLzGvnZPXLrTsJfyHPrFsnp4yoKn+Ap/8NNZgWKZG9o5+qotH8tAa8AXn8gTN5A==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -2591,13 +2591,13 @@
       }
     },
     "@darkobits/ts-unified": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@darkobits/ts-unified/-/ts-unified-5.2.0.tgz",
-      "integrity": "sha512-V/h1wP32mNPWYPNlFY+jqi+Su4dHWgSIU3q+yr39Ctd5dhwLp9ybMdWiJomicLzZK8O0mrGu3yKCrs9peEtcgA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@darkobits/ts-unified/-/ts-unified-5.2.1.tgz",
+      "integrity": "sha512-3dCFE3+zfVbkB6L3CKd3t6p+FKDoLSReMOsq8hHh+XMdyfIkAfoz4KeCXpRujhkCZMr/8Zd8zVBbnnzAGfcgsw==",
       "dev": true,
       "requires": {
         "@babel/cli": "^7.10.5",
-        "@babel/core": "^7.11.0",
+        "@babel/core": "^7.11.1",
         "@babel/plugin-proposal-class-properties": "^7.10.4",
         "@babel/plugin-proposal-decorators": "^7.10.5",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
@@ -2607,10 +2607,10 @@
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-typescript": "^7.10.4",
         "@babel/register": "^7.10.5",
-        "@babel/runtime": "^7.11.0",
+        "@babel/runtime": "^7.11.1",
         "@darkobits/log": "^2.0.0-beta.15",
-        "@typescript-eslint/eslint-plugin": "^3.7.1",
-        "@typescript-eslint/parser": "^3.7.1",
+        "@typescript-eslint/eslint-plugin": "^3.8.0",
+        "@typescript-eslint/parser": "^3.8.0",
         "@zerollup/ts-transform-paths": "^1.7.18",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^26.2.2",
@@ -2658,16 +2658,16 @@
           }
         },
         "@babel/core": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.0.tgz",
-          "integrity": "sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==",
+          "version": "7.11.1",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
+          "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.11.0",
             "@babel/helper-module-transforms": "^7.11.0",
             "@babel/helpers": "^7.10.4",
-            "@babel/parser": "^7.11.0",
+            "@babel/parser": "^7.11.1",
             "@babel/template": "^7.10.4",
             "@babel/traverse": "^7.11.0",
             "@babel/types": "^7.11.0",
@@ -2962,9 +2962,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
-          "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
+          "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==",
           "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
@@ -3156,9 +3156,9 @@
           }
         },
         "@babel/plugin-transform-block-scoping": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
-          "integrity": "sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==",
+          "version": "7.11.1",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
+          "integrity": "sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==",
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
@@ -3608,9 +3608,9 @@
           }
         },
         "@babel/runtime": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.0.tgz",
-          "integrity": "sha512-qArkXsjJq7H+T86WrIFV0Fnu/tNOkZ4cgXmjkzAu3b/58D5mFIO8JH/y77t7C9q0OdDRdh9s7Ue5GasYssxtXw==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -5613,9 +5613,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.158",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.158.tgz",
-      "integrity": "sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==",
+      "version": "4.14.159",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.159.tgz",
+      "integrity": "sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==",
       "dev": true
     },
     "@types/long": {
@@ -5906,12 +5906,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.7.1.tgz",
-      "integrity": "sha512-3DB9JDYkMrc8Au00rGFiJLK2Ja9CoMP6Ut0sHsXp3ZtSugjNxvSSHTnKLfo4o+QmjYBJqEznDqsG1zj4F2xnsg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.8.0.tgz",
+      "integrity": "sha512-lFb4VCDleFSR+eo4Ew+HvrJ37ZH1Y9ZyE+qyP7EiwBpcCVxwmUc5PAqhShCQ8N8U5vqYydm74nss+a0wrrCErw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.7.1",
+        "@typescript-eslint/experimental-utils": "3.8.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -5943,45 +5943,45 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.1.tgz",
-      "integrity": "sha512-TqE97pv7HrqWcGJbLbZt1v59tcqsSVpWTOf1AqrWK7n8nok2sGgVtYRuGXeNeLw3wXlLEbY1MKP3saB2HsO/Ng==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.8.0.tgz",
+      "integrity": "sha512-o8T1blo1lAJE0QDsW7nSyvZHbiDzQDjINJKyB44Z3sSL39qBy5L10ScI/XwDtaiunoyKGLiY9bzRk4YjsUZl8w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/types": "3.7.1",
-        "@typescript-eslint/typescript-estree": "3.7.1",
+        "@typescript-eslint/types": "3.8.0",
+        "@typescript-eslint/typescript-estree": "3.8.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.7.1.tgz",
-      "integrity": "sha512-W4QV/gXvfIsccN8225784LNOorcm7ch68Fi3V4Wg7gmkWSQRKevO4RrRqWo6N/Z/myK1QAiGgeaXN57m+R/8iQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.8.0.tgz",
+      "integrity": "sha512-u5vjOBaCsnMVQOvkKCXAmmOhyyMmFFf5dbkM3TIbg3MZ2pyv5peE4gj81UAbTHwTOXEwf7eCQTUMKrDl/+qGnA==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.7.1",
-        "@typescript-eslint/types": "3.7.1",
-        "@typescript-eslint/typescript-estree": "3.7.1",
+        "@typescript-eslint/experimental-utils": "3.8.0",
+        "@typescript-eslint/types": "3.8.0",
+        "@typescript-eslint/typescript-estree": "3.8.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.7.1.tgz",
-      "integrity": "sha512-PZe8twm5Z4b61jt7GAQDor6KiMhgPgf4XmUb9zdrwTbgtC/Sj29gXP1dws9yEn4+aJeyXrjsD9XN7AWFhmnUfg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.8.0.tgz",
+      "integrity": "sha512-8kROmEQkv6ss9kdQ44vCN1dTrgu4Qxrd2kXr10kz2NP5T8/7JnEfYNxCpPkArbLIhhkGLZV3aVMplH1RXQRF7Q==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.1.tgz",
-      "integrity": "sha512-m97vNZkI08dunYOr2lVZOHoyfpqRs0KDpd6qkGaIcLGhQ2WPtgHOd/eVbsJZ0VYCQvupKrObAGTOvk3tfpybYA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.8.0.tgz",
+      "integrity": "sha512-MTv9nPDhlKfclwnplRNDL44mP2SY96YmPGxmMbMy6x12I+pERcxpIUht7DXZaj4mOKKtet53wYYXU0ABaiXrLw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "3.7.1",
-        "@typescript-eslint/visitor-keys": "3.7.1",
+        "@typescript-eslint/types": "3.8.0",
+        "@typescript-eslint/visitor-keys": "3.8.0",
         "debug": "^4.1.1",
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
@@ -6014,9 +6014,9 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.1.tgz",
-      "integrity": "sha512-xn22sQbEya+Utj2IqJHGLA3i1jDzR43RzWupxojbSWnj3nnPLavaQmWe5utw03CwYao3r00qzXfgJMGNkrzrAA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.8.0.tgz",
+      "integrity": "sha512-gfqQWyVPpT9NpLREXNR820AYwgz+Kr1GuF3nf1wxpHD6hdxI62tq03ToomFnDxY0m3pUB39IF7sil7D5TQexLA==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -18920,6 +18920,11 @@
         "retry": "^0.12.0"
       }
     },
+    "p-throttle": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-3.1.0.tgz",
+      "integrity": "sha512-rLo81NXBihs3GJQhq89IXa0Egj/sbW1zW8/qnyadOwUhIUrZSUvyGdQ46ISRKELFBkVvmMJ4JUqWki4oAh30Qw=="
+    },
     "p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -19966,6 +19971,14 @@
         "camelcase": "^5.0.0"
       }
     },
+    "react-intersection-observer": {
+      "version": "8.26.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.26.2.tgz",
+      "integrity": "sha512-GmSjLNK+oV7kS+BHfrJSaA4wF61ELA33gizKHmN+tk59UT6/aW8kkqvlrFGPwxGoaIzLKS2evfG5fgkw5MIIsg==",
+      "requires": {
+        "tiny-invariant": "^1.1.0"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -20023,6 +20036,15 @@
       "integrity": "sha512-vAiiHUhPcT5NYwKutvbAgHR2HXoESkTyaeXQaW1cmVwZujhmHEfaXRh28uS52jQaja/S+Xrc0aFizfljY7rvAw==",
       "requires": {
         "prop-types": "^15.6.0"
+      }
+    },
+    "react-scroll-percentage": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-scroll-percentage/-/react-scroll-percentage-4.2.0.tgz",
+      "integrity": "sha512-mJgX+YCRcEzX8jDkAm8pv+gfBFJFO+t8tIANOGcEjFfGFhLTNWs9OJakC4laL5LZXyImohFE5N30XLaA2Ng95g==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "react-intersection-observer": "^8.25.1"
       }
     },
     "react-syntax-highlighter": {
@@ -22948,9 +22970,9 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "localforage": "^1.9.0",
     "modernizr": "^3.11.3",
     "p-queue": "^6.6.0",
+    "p-throttle": "^3.1.0",
     "p-wait-for": "^3.1.0",
     "polished": "^3.6.5",
     "query-string": "^6.13.1",
@@ -51,6 +52,7 @@
     "react-linkify": "^1.0.0-alpha",
     "react-router-dom": "^5.2.0",
     "react-router-hash-link": "^2.0.0",
+    "react-scroll-percentage": "^4.2.0",
     "react-syntax-highlighter": "^13.2.1",
     "react-waypoint": "^9.0.3",
     "use-async-effect": "^2.2.2",
@@ -58,7 +60,7 @@
     "webp-hero": "0.0.0-dev.24"
   },
   "devDependencies": {
-    "@darkobits/ts-unified": "^5.2.0",
+    "@darkobits/ts-unified": "^5.2.1",
     "@hot-loader/react-dom": "^16.13.0",
     "@signalstickers/fetch-sticker-data-webpack-plugin": "^1.0.0",
     "@svgr/webpack": "^5.4.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,21 +1,11 @@
 import {hot} from 'react-hot-loader/root';
-import React, {Suspense} from 'react';
+import React from 'react';
 import {IconContext} from 'react-icons';
-import {
-  BrowserRouter as Router,
-  Switch,
-  Route
-} from 'react-router-dom';
+import {BrowserRouter as Router} from 'react-router-dom';
 
+import AppLayout from 'components/layout/AppLayout';
 import {Provider as StickersContextProvider} from 'contexts/StickersContext';
-import Navbar from 'components/layout/Navbar';
-import SuspenseFallback from 'components/layout/SuspenseFallback';
-
-// Note: Each top-level route should be imported az a lazy-loaded component.
-const About = React.lazy(async () => import('components/about/About'));
-const Contribute = React.lazy(async () => import('components/contribute/Contribute'));
-const Home = React.lazy(async () => import('components/home/Home'));
-const Pack = React.lazy(async () => import('components/pack/StickerPackDetail'));
+import {Provider as AppStateContextProvider} from 'contexts/AppStateContext';
 
 
 const App: React.FunctionComponent = () => {
@@ -32,29 +22,13 @@ const App: React.FunctionComponent = () => {
           }
         }}
       >
-        <Router>
+        <AppStateContextProvider>
           <StickersContextProvider>
-            <Navbar />
-            <div className="container d-flex flex-grow-1 flex-column">
-              <Suspense fallback={<SuspenseFallback />}>
-                <Switch>
-                  <Route exact path="/">
-                    <Home />
-                  </Route>
-                  <Route path="/pack/:packId">
-                    <Pack />
-                  </Route>
-                  <Route path="/contribute">
-                    <Contribute />
-                  </Route>
-                  <Route path="/about">
-                    <About />
-                  </Route>
-                </Switch>
-              </Suspense>
-            </div>
+            <Router>
+              <AppLayout />
+            </Router>
           </StickersContextProvider>
-        </Router>
+        </AppStateContextProvider>
       </IconContext.Provider>
     </React.StrictMode>
   );

--- a/src/components/contribute/Contribute.tsx
+++ b/src/components/contribute/Contribute.tsx
@@ -38,10 +38,6 @@ const Contribute = styled.div`
   & pre[class*="language-"] {
     margin: 0;
   }
-
-  & a.btn-success {
-    color: white;
-  }
 `;
 
 
@@ -241,7 +237,7 @@ const ContributeComponent: React.FunctionComponent = () => {
       Signal Stickers repository
     </ExternalLink>
   ), []);
-  
+
   const twitterLink = React.useMemo(() => (
     <ExternalLink
       href="https://twitter.com/signalstickers"

--- a/src/components/contribute/Contribute.tsx
+++ b/src/components/contribute/Contribute.tsx
@@ -22,8 +22,6 @@ import {getStickerPackDirectory, getStickerPack} from 'lib/stickers';
 // ----- Styles ----------------------------------------------------------------
 
 const Contribute = styled.div`
-  background-color: white;
-
   /**
    * Ensures error feedback containers are always visible (even if empty) so
    * that controls do not jump around as they move between valid and invalid
@@ -306,7 +304,7 @@ const ContributeComponent: React.FunctionComponent = () => {
                       id="signal-art-url"
                       name="signalArtUrl"
                       validate={validators.signalArtUrl}
-                      className={cx('form-control', errors.signalArtUrl && 'is-invalid')}
+                      className={cx('form-control', 'mt-2', errors.signalArtUrl && 'is-invalid')}
                       placeholder="https://signal.art/addstickers/#pack_id=<your pack id>&pack_key=<your pack key>"
                     />
                     <div className="invalid-feedback">
@@ -326,7 +324,7 @@ const ContributeComponent: React.FunctionComponent = () => {
                       id="source"
                       name="source"
                       validate={validators.source}
-                      className={cx('form-control', errors.source && 'is-invalid')}
+                      className={cx('form-control', 'mt-2', errors.source && 'is-invalid')}
                     />
                     <small className="form-text text-muted">Original author, website, company, etc.</small>
                     <div className="invalid-feedback">
@@ -346,7 +344,7 @@ const ContributeComponent: React.FunctionComponent = () => {
                       id="tags"
                       name="tags"
                       validate={validators.tags}
-                      className={cx('form-control', errors.tags && 'is-invalid')}
+                      className={cx('form-control', 'mt-2', errors.tags && 'is-invalid')}
                     />
                     <small className="form-text text-muted">Comma-separated list of words.</small>
                     <div className="invalid-feedback">

--- a/src/components/contribute/Contribute.tsx
+++ b/src/components/contribute/Contribute.tsx
@@ -38,6 +38,10 @@ const Contribute = styled.div`
   & pre[class*="language-"] {
     margin: 0;
   }
+
+  & a.btn-success {
+    color: white;
+  }
 `;
 
 

--- a/src/components/home/SearchResults.tsx
+++ b/src/components/home/SearchResults.tsx
@@ -1,5 +1,5 @@
 import {styled} from 'linaria/react';
-import React, {useState, useContext} from 'react';
+import React from 'react';
 import {Link} from 'react-router-dom';
 import {Waypoint} from 'react-waypoint';
 import * as R from 'ramda';
@@ -29,11 +29,11 @@ const PAGE_SIZE = 64;
 
 
 const StickerPackListComponent = () => {
-  const {searchResults} = useContext(StickersContext);
+  const {searchResults} = React.useContext(StickersContext);
   // Used by Waypoint to persist the component across re-renders.
-  const [cursor, setCursor] = useState(0);
+  const [cursor, setCursor] = React.useState(0);
   // Subset of total search results that have been rendered.
-  const [renderedSearchResults, setRenderedSearchResults] = useState<typeof searchResults>([]);
+  const [renderedSearchResults, setRenderedSearchResults] = React.useState<typeof searchResults>([]);
 
 
   /**

--- a/src/components/home/StickerPackPreviewCard.tsx
+++ b/src/components/home/StickerPackPreviewCard.tsx
@@ -1,7 +1,9 @@
-import React, {useState} from 'react';
 import {styled} from 'linaria/react';
+import {rgba} from 'polished';
+import React from 'react';
 import useAsyncEffect from 'use-async-effect';
 
+import {GRAY_DARKER_2, GRAY_DARKER} from 'etc/colors';
 import {StickerPackPartial} from 'etc/types';
 import {getConvertedStickerInPack} from 'lib/stickers';
 
@@ -12,67 +14,78 @@ export interface Props {
   stickerPack: StickerPackPartial;
 }
 
+interface StickerPackPreviewCardProps extends React.ComponentProps<'div'> {
+  nsfw?: boolean;
+  original?: boolean;
+  animated?: boolean;
+}
+
 
 // ----- Styles ----------------------------------------------------------------
 
-const StickerPackPreviewCard = styled.div<React.ComponentProps<'div'> & {nsfw?: boolean} & {original?: boolean} & {animated?: boolean} >`
+const StickerPackPreviewCard = styled.div<StickerPackPreviewCardProps>`
+  background-color: transparent;
   text-align: center;
   transition: box-shadow 0.15s ease-in-out;
   overflow: hidden;
 
-  &::before, &::after{
-    top: 13px;
-    position: absolute;
-    padding: 3px 6px 3px 3px;
-    box-shadow: 0px 0px 5px 3px rgba(0,0,0,0.2);
+  &::before, &::after {
     color: white;
     font-size: 12px;
+    padding: 3px 6px 3px 3px;
+    position: absolute;
+    top: 13px;
   }
 
-  &::before{
+  &::before {
     content: 'Original';
-    left: 0;
-    display: ${props => (props.original ? 'block' : 'none')};
-    background-color: #3a76f0;
+    background-color: var(--primary);
     border-bottom-right-radius: 4px;
     border-top-right-radius: 4px;
+    color: var(--white);
+    display: ${props => props.original ? 'block' : 'none'};
+    font-size: 12px;
+    left: 0;
+    left: O;
+    padding: 3px 6px;
+    position: absolute;
+    top: 13px;
   }
 
-  &::after{
+  &::after {
     content: 'Animated';
-    right: 0;
-    display: ${props => (props.animated ? 'block' : 'none')};
-    background-color: #f57f17;
+    background-color: var(--orange);
     border-bottom-left-radius: 4px;
     border-top-left-radius: 4px;
+    display: ${props => props.animated ? 'block' : 'none'};
+    padding: 3px 6px;
+    right: 0;
   }
 
   & .card-img-top {
+    filter: ${props => props.nsfw ? 'blur(4px)' : 'none'};
     height: 72px;
-    width: 72px;
-    object-fit: contain;
-    margin-top: 24px;
     margin-bottom: 24px;
     margin-left: auto;
     margin-right: auto;
+    margin-top: 24px;
+    object-fit: contain;
     transition: transform 0.15s ease-in;
-    filter: ${props => (props.nsfw ? 'blur(4px)' : 'none')};
+    width: 72px;
   }
 
   & .card-header {
     border-bottom: none;
     border-top: 1px solid rgba(0, 0, 0, 0.125);
-    color: black;
     font-size: 14px;
-    white-space: nowrap;
     overflow: hidden;
     position: relative;
+    white-space: nowrap;
 
     &::after {
-      background: linear-gradient(90deg, rgba(247, 247, 247, 0) 0%, rgba(247, 247, 247, 1) 50%);
+      content: ' ';
       border-bottom-right-radius: 4px;
       bottom: 0;
-      content: ' ';
       display: block;
       pointer-events: none;
       position: absolute;
@@ -93,13 +106,49 @@ const StickerPackPreviewCard = styled.div<React.ComponentProps<'div'> & {nsfw?: 
 
     box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.2);
   }
+
+  .theme-light & {
+    &::before, &::after {
+      box-shadow: 0px 0px 5px 3px rgba(0, 0, 0, 0.2);
+    }
+
+    & .card-header {
+      color: var(--dark);
+
+      &::after {
+        /* This color is a one-off (even in Bootstrap) used for card headers. */
+        background: linear-gradient(90deg, rgba(247, 247, 247, 0) 0%, rgba(247, 247, 247, 1) 50%);
+      }
+    }
+  }
+
+  .theme-dark & {
+    background-color: var(--gray-dark);
+    border-color: ${GRAY_DARKER};
+    color: var(--light);
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.15);
+
+    &:hover {
+      box-shadow: 1px 1px 8px rgba(0, 0, 0, 0.25);
+    }
+
+    & .card-header {
+      background-color: ${GRAY_DARKER_2};
+      border-color: ${GRAY_DARKER};
+      color: var(--light);
+
+      &::after {
+        background: linear-gradient(90deg, ${rgba(GRAY_DARKER_2, 0)} 0%, ${rgba(GRAY_DARKER_2, 1)} 50%);
+      }
+    }
+  }
 `;
 
 
 // ----- Component -------------------------------------------------------------
 
 const StickerPackPreviewCardComponent: React.FunctionComponent<Props> = props => {
-  const [cover, setCover] = useState<string | undefined>();
+  const [cover, setCover] = React.useState<string | undefined>();
   const {meta, manifest} = props.stickerPack;
 
 
@@ -134,11 +183,13 @@ const StickerPackPreviewCardComponent: React.FunctionComponent<Props> = props =>
       nsfw={meta.nsfw}
       aria-label={title}
     >
-      {cover
-        ? <img className="card-img-top" src={cover} alt="Cover" />
-        : <div className="card-img-top">{' '}</div>
+      {cover ?
+        <img className="card-img-top" src={cover} alt="Cover" /> :
+        <div className="card-img-top">{' '}</div>
       }
-      <div className="card-header">{title}</div>
+      <div className="card-header">
+        {title}
+      </div>
     </StickerPackPreviewCard>
   );
 };

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -64,7 +64,8 @@ export const globals = css`
         }
       }
 
-      & .btn-primary {
+      & .btn-primary,
+      & .btn-success {
         color: var(--light);
 
         &:hover {
@@ -74,7 +75,6 @@ export const globals = css`
 
       & .btn-secondary {
         background-color: var(--secondary);
-
       }
 
       & .card {

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,233 @@
+import {css} from 'linaria';
+import {styled} from 'linaria/react';
+import pThrottle from 'p-throttle';
+import {rgba} from 'polished';
+import React, {Suspense} from 'react';
+import {Switch, Route} from 'react-router-dom';
+import {useScrollPercentage} from 'react-scroll-percentage';
+import useAsyncEffect from 'use-async-effect';
+
+import Navbar from 'components/layout/Navbar';
+import SuspenseFallback from 'components/layout/SuspenseFallback';
+import AppStateContext from 'contexts/AppStateContext';
+import {
+  GRAY_DARKER_2,
+  GRAY_LIGHTER,
+  GRAY_DARKER,
+  PRIMARY_DARKER,
+  PRIMARY_LIGHTER,
+  DARK_THEME_BACKGROUND
+} from 'etc/colors';
+
+
+// Note: Each top-level route should be imported az a lazy-loaded component.
+const About = React.lazy(async () => import('components/about/About'));
+const Contribute = React.lazy(async () => import('components/contribute/Contribute'));
+const Home = React.lazy(async () => import('components/home/Home'));
+const Pack = React.lazy(async () => import('components/pack/StickerPackDetail'));
+
+
+// ----- Styles ----------------------------------------------------------------
+
+/**
+ * Global styles that we need to define using JavaScript. Exported to appease
+ * the linter.
+ */
+export const globals = css`
+  :global() {
+    & .theme-light {
+      & .form-control {
+        &:not(.is-invalid) {
+          border-color: rgba(0, 0, 0, 0.125);
+
+          &:focus {
+            box-shadow: 0 0 0 0.15rem ${rgba(GRAY_LIGHTER, 0.25)};
+          }
+        }
+      }
+    }
+
+    & .theme-dark {
+      & .btn-light {
+        background-color: var(--gray-dark);
+        border-color: ${GRAY_DARKER};
+        color: var(--light);
+
+        &:hover {
+          background-color: ${GRAY_DARKER_2};
+          color: var(--light);
+        }
+
+        &:active:focus {
+          background-color: ${GRAY_DARKER_2};
+          color: var(--light);
+        }
+      }
+
+      & .btn-primary {
+        color: var(--light);
+
+        &:hover {
+          color: var(--light);
+        }
+      }
+
+      & .btn-secondary {
+        background-color: var(--secondary);
+
+      }
+
+      & .card {
+        background-color: ${GRAY_DARKER_2};
+        border-color: ${GRAY_DARKER};
+        box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.15);
+      }
+
+      & .form-control {
+        background-color: ${GRAY_DARKER_2};
+        color: inherit;
+
+        &:not(.is-invalid) {
+          border-color: ${GRAY_DARKER};
+
+          &:focus {
+            border-color: ${GRAY_LIGHTER};
+            box-shadow: 0 0 0 0.15rem ${rgba(GRAY_LIGHTER, 0.25)};
+          }
+        }
+      }
+
+      & .modal-header,
+      & .modal-footer {
+        border-color: ${GRAY_DARKER};
+      }
+
+      /* !important is needed here because Bootstrap uses it as well. */
+      & .text-dark {
+        color: var(--light) !important;
+      }
+
+      & .text-muted {
+        color: ${GRAY_LIGHTER} !important;
+      }
+
+      & a,
+      & .btn.btn-link {
+        color: var(--primary);
+
+        &:hover {
+          color: ${PRIMARY_LIGHTER};
+        }
+      }
+
+      & hr {
+        border-color: ${GRAY_DARKER};
+      }
+
+      & pre {
+        color: var(--light);
+      }
+    }
+  }
+`;
+
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+
+  .theme-light & {
+    background-color: var(--white);
+    color: var(--dark);
+  }
+
+  .theme-dark & {
+    background-color: ${DARK_THEME_BACKGROUND};
+    color: var(--light);
+  }
+`;
+
+
+// ----- Component -------------------------------------------------------------
+
+const AppLayout: React.FunctionComponent = () => {
+  const useAppState = React.useContext(AppStateContext);
+  const [darkMode] = useAppState<boolean>('darkMode');
+  const [ref, percentage] = useScrollPercentage();
+
+
+  /**
+   * [Effect]
+   *
+   * Apply classes to <body> to indicate the current theme. We do this here
+   * (even though we are a child of <body>) because this is the highest level
+   * React component in our tree that renders actual HTML.
+   */
+  React.useEffect(() => {
+    const bodyEl = document.querySelector('body');
+
+    if (!bodyEl) {
+      return;
+    }
+
+    if (darkMode) {
+      bodyEl.classList.add('theme-dark');
+      bodyEl.classList.remove('theme-light');
+    } else {
+      bodyEl.classList.add('theme-light');
+      bodyEl.classList.remove('theme-dark');
+    }
+  }, [darkMode]);
+
+
+  /**
+   * [Effect]
+   *
+   * Ensures that the background color shown during over-scroll matches adjacent
+   * content. Unfortunately the only way this can be reliably done at the moment
+   * is by changing the body's background color. To minimize performance impact,
+   * we run this function asynchronously and throttle calls to a maximum of 10
+   * times per second.
+   */
+  useAsyncEffect(pThrottle(() => {
+    const bodyEl = document.querySelector('body');
+
+    if (!bodyEl) {
+      return;
+    }
+
+    if (darkMode) {
+      bodyEl.style.backgroundColor = percentage < 0.5 ? PRIMARY_DARKER : 'var(--dark)';
+    } else {
+      bodyEl.style.backgroundColor = percentage < 0.5 ? 'var(--primary)' : 'var(--white)';
+    }
+  }, 10, 1000), [percentage, darkMode]);
+
+
+  return (<>
+    <Navbar />
+    <StyledContainer ref={ref}>
+      <div className="container d-flex flex-column flex-grow-1">
+        <Suspense fallback={<SuspenseFallback />}>
+          <Switch>
+            <Route exact path="/">
+              <Home />
+            </Route>
+            <Route path="/pack/:packId">
+              <Pack />
+            </Route>
+            <Route path="/contribute">
+              <Contribute />
+            </Route>
+            <Route path="/about">
+              <About />
+            </Route>
+          </Switch>
+        </Suspense>
+      </div>
+    </StyledContainer>
+  </>);
+};
+
+
+export default AppLayout;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,15 +1,20 @@
-import React from 'react';
-import {FaGithub, FaTwitter} from 'react-icons/fa';
-import {BsBoxArrowUpRight, BsList} from 'react-icons/bs';
-import {Link, NavLink} from 'react-router-dom';
 import {styled} from 'linaria/react';
 import {darken} from 'polished';
+import React from 'react';
+import {BsBoxArrowUpRight, BsList} from 'react-icons/bs';
+import {FaGithub, FaTwitter} from 'react-icons/fa';
+import {FiSun, FiMoon} from 'react-icons/fi';
+import {Link, NavLink} from 'react-router-dom';
 
 import signalStickersLogoUrl from 'assets/favicon.png';
 import ExternalLink from 'components/general/ExternalLink';
+import AppStateContext from 'contexts/AppStateContext';
+import {PRIMARY_DARKER} from 'etc/colors';
 import {NAVBAR_HEIGHT} from 'etc/constants';
 import {bp} from 'lib/utils';
 
+
+// ----- Types -----------------------------------------------------------------
 
 interface NavLinkDescriptor {
   title: string;
@@ -66,18 +71,16 @@ const StyledNav = styled.nav`
     }
   }
 
-  /* Creates border between the navbar and menu items when open (on mobile). */
-  & .container {
-    &:before {
-      content: '';
-      display: block;
-      position: absolute;
-      width: 200vw;
-      left: -100vw;
-      top: ${NAVBAR_HEIGHT + 1}px;
-      height: 1px;
-      background-color: rgba(255, 255, 255, 0.33);
-    }
+  /* Creates a border between the navbar and menu items when open (on mobile). */
+  & .container::before {
+    content: '';
+    display: block;
+    position: absolute;
+    width: 200vw;
+    left: -100vw;
+    top: ${NAVBAR_HEIGHT + 1}px;
+    height: 1px;
+    background-color: rgba(255, 255, 255, 0.33);
   }
 
   & .navbar-brand {
@@ -121,12 +124,27 @@ const StyledNav = styled.nav`
     fill: ${darken(0.1, 'white')};
     transform: scale(1.2) translateY(1px);
   }
+
+  .theme-light & {
+    background-color: var(--primary);
+  }
+
+  .theme-dark & {
+    background-color: ${PRIMARY_DARKER};
+
+    & .navbar-brand img {
+      filter: brightness(0.75);
+    }
+  }
 `;
 
 
 // ----- Component -------------------------------------------------------------
 
 const NavbarComponent: React.FunctionComponent = () => {
+  const useAppState = React.useContext(AppStateContext);
+  const [darkMode, setDarkMode] = useAppState<boolean>('darkMode');
+
   const NAVBAR_TOGGLE_ID = 'navbar-toggle';
 
   const navLinks: Array<NavLinkDescriptor> = [{
@@ -159,6 +177,14 @@ const NavbarComponent: React.FunctionComponent = () => {
 
 
   /**
+   * Toggles dark mode.
+   */
+  const toggleDarkMode = React.useCallback(() => {
+    setDarkMode(!darkMode);
+  }, [darkMode]);
+
+
+  /**
    * Closes the navigation menu (on small devices) upon navigation.
    */
   const collapseNavigation = React.useCallback(() => {
@@ -167,7 +193,7 @@ const NavbarComponent: React.FunctionComponent = () => {
 
 
   return (
-    <StyledNav className="navbar navbar-expand-md navbar-dark bg-primary">
+    <StyledNav className="navbar navbar-expand-md navbar-dark">
       <div className="container">
         <Link to="/" className="navbar-brand" onClick={collapseNavigation}>
           <img src={signalStickersLogoUrl} alt="Signal Stickers Logo" /> Signal Stickers
@@ -207,6 +233,16 @@ const NavbarComponent: React.FunctionComponent = () => {
                 }
               </li>
             ))}
+            <li className="nav-item">
+              <button
+                type="button"
+                className="btn btn-link nav-link py-3 py-md-2"
+                title="Dark Mode"
+                onClick={toggleDarkMode}
+              >
+                <span className="d-inline-block d-md-none mr-1">Dark Mode</span> {darkMode ? <FiMoon /> : <FiSun />}
+              </button>
+            </li>
           </ul>
         </div>
       </div>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -240,7 +240,20 @@ const NavbarComponent: React.FunctionComponent = () => {
                 title="Dark Mode"
                 onClick={toggleDarkMode}
               >
-                <span className="d-inline-block d-md-none mr-1">Dark Mode</span> {darkMode ? <FiMoon /> : <FiSun />}
+                {darkMode ?
+                  <>
+                    <span className="d-inline-block d-md-none mr-1">
+                      Light mode
+                    </span>
+                    <FiSun />
+                  </>
+                  :
+                  <>
+                    <span className="d-inline-block d-md-none mr-1">
+                      Dark mode
+                    </span>
+                    <FiMoon />
+                  </>}
               </button>
             </li>
           </ul>

--- a/src/components/pack/NsfwModal.tsx
+++ b/src/components/pack/NsfwModal.tsx
@@ -5,6 +5,7 @@ import {Link} from 'react-router-dom';
 import React, {useEffect} from 'react';
 
 import ExternalLink from 'components/general/ExternalLink';
+import {DARK_THEME_BACKGROUND} from 'etc/colors';
 import {NAVBAR_HEIGHT} from 'etc/constants';
 
 
@@ -37,6 +38,16 @@ const NsfwModal = styled.div`
 
   & svg {
     transform: translateY(-2px);
+  }
+
+  .theme-dark & {
+    background: rgba(42, 42, 42, ${() => (Modernizr.backdropfilter ? 0.75 : 1)});
+
+    & .modal-content {
+      /* background-color: blue !important; */
+      background-color: ${DARK_THEME_BACKGROUND};
+      color: var(--white);
+    }
   }
 `;
 
@@ -96,7 +107,7 @@ const NsfwModalComponent: React.FunctionComponent = () => {
           <div className="modal-footer">
             <Link
               to="/"
-              className="btn btn-secondary"
+              className="btn btn-light"
               title="Go back home"
             >
               Go back home

--- a/src/components/pack/Sticker.tsx
+++ b/src/components/pack/Sticker.tsx
@@ -1,7 +1,8 @@
-import React, {useState} from 'react';
 import {styled} from 'linaria/react';
+import React, {useState} from 'react';
 import useAsyncEffect from 'use-async-effect';
 
+import {GRAY_DARKER} from 'etc/colors';
 import {getConvertedStickerInPack, getEmojiForSticker} from 'lib/stickers';
 
 
@@ -30,7 +31,7 @@ const Sticker = styled.div`
   & .emoji {
     position: absolute;
     top: 2px;
-    left: 6px;
+    left: 5px;
     opacity: 0.75;
   }
 
@@ -51,6 +52,15 @@ const Sticker = styled.div`
     width: 1px;
     height: 0px;
     padding-bottom: calc(100%);
+  }
+
+  .theme-light & {
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.08);
+  }
+
+  .theme-dark & {
+    border-color: ${GRAY_DARKER};
+    box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.15);
   }
 `;
 
@@ -87,15 +97,15 @@ const StickerComponent: React.FunctionComponent<Props> = ({packId, packKey, stic
   // ----- Render --------------------------------------------------------------
 
   return (
-    <Sticker className="shadow-sm">
-      {emoji && stickerSrc
-        ? <>
-            <div className="emoji">{emoji}</div>
-            <img src={stickerSrc} alt="Sticker" />
-        </>
-        : <div className="spinner-border text-light" role="status">
-            <span className="sr-only">Loading...</span>
-          </div>
+    <Sticker>
+      {emoji && stickerSrc ?
+        <>
+          <div className="emoji">{emoji}</div>
+          <img src={stickerSrc} alt="Sticker" />
+        </> :
+        <div className="spinner-border text-light" role="status">
+          <span className="sr-only">Loading...</span>
+        </div>
       }
     </Sticker>
   );

--- a/src/components/pack/StickerPackDetail.tsx
+++ b/src/components/pack/StickerPackDetail.tsx
@@ -1,3 +1,4 @@
+import {styled} from 'linaria/react';
 import React, {useState, useContext} from 'react';
 import {
   BsArrowLeftShort,
@@ -10,11 +11,11 @@ import {
 } from 'react-icons/bs';
 import {Link, useParams, useHistory} from 'react-router-dom';
 import Linkify from 'react-linkify';
-import {styled} from 'linaria/react';
 import useAsyncEffect from 'use-async-effect';
 
 import ExternalLink from 'components/general/ExternalLink';
 import StickersContext from 'contexts/StickersContext';
+import {GRAY_DARKER} from 'etc/colors';
 import {StickerPack} from 'etc/types';
 import useQuery from 'hooks/use-query';
 import {getStickerPack} from 'lib/stickers';
@@ -39,8 +40,6 @@ export interface UrlParams {
 // ----- Styles ----------------------------------------------------------------
 
 const StickerPackDetail = styled.div`
-  background-color: white;
-
   & h1 {
     font-size: 2rem;
   }
@@ -70,6 +69,7 @@ const StickerPackDetail = styled.div`
 
   & .list-group-item {
     align-items: center;
+    background-color: transparent;
     display: flex;
     flex-direction: row;
     font-size: 14px;
@@ -87,6 +87,14 @@ const StickerPackDetail = styled.div`
 
     & .list-group-item {
       font-size: inherit;
+    }
+  }
+
+  .theme-dark & {
+    border-color: ${GRAY_DARKER};
+
+    & .list-group-item {
+      border-color: ${GRAY_DARKER};
     }
   }
 `;
@@ -172,10 +180,11 @@ const StickerPackDetailComponent: React.FunctionComponent = () => {
     packId
   ]);
 
+
   /**
    * [Event Handler] Search for packs from the same author
    */
-  const onAuthorClick = (event: React.SyntheticEvent) => {
+  const onAuthorClick = React.useCallback((event: React.SyntheticEvent) => {
     event.preventDefault();
 
     if (searcher && event.currentTarget.textContent) {
@@ -187,7 +196,11 @@ const StickerPackDetailComponent: React.FunctionComponent = () => {
 
       history.push('/');
     }
-  };
+  }, [
+    history,
+    searcher,
+    setSearchQuery
+  ]);
 
 
   // ----- Render --------------------------------------------------------------
@@ -236,10 +249,7 @@ const StickerPackDetailComponent: React.FunctionComponent = () => {
 
   return (
     <StickerPackDetail className="px-1 px-sm-4 py-4 mt-0 my-sm-4">
-      {stickerPack.meta.nsfw
-        ? <NsfwModal />
-        : null
-      }
+      {stickerPack.meta.nsfw && <NsfwModal />}
 
       {/* Header */}
       <div className="row mb-4 flex-column-reverse flex-lg-row">
@@ -258,11 +268,11 @@ const StickerPackDetailComponent: React.FunctionComponent = () => {
           </div>
         </div>
         <div className="col-12 col-lg-4 d-flex d-lg-block justify-content-between text-md-right mb-3 mb-lg-0">
-          {stickerPack.meta.unlisted
-            ? null
-            : <Link to="/" className="btn btn-light mr-2">
-                <BsArrowLeftShort className="arrow-left-icon" /> Back
-              </Link>
+          {stickerPack.meta.unlisted ?
+            null :
+            <Link to="/" className="btn btn-light mr-2">
+              <BsArrowLeftShort className="arrow-left-icon" /> Back
+            </Link>
           }
           <ExternalLink
             href={`https://signal.art/addstickers/#pack_id=${packId}&pack_key=${stickerPack.meta.key}`}
@@ -275,61 +285,57 @@ const StickerPackDetailComponent: React.FunctionComponent = () => {
       </div>
 
       {/* Metadata Table */}
-      {stickerPack.meta.unlisted
-        ? null
-        : <div className="row mb-4">
-            <div className="col-12 col-lg-9">
-              <ul className="list-group">
+      {!stickerPack.meta.unlisted &&
+        <div className="row mb-4">
+          <div className="col-12 col-lg-9">
+            <ul className="list-group">
 
-                {/* Original */}
-                {stickerPack.meta.original
-                  ? <li className="list-group-item text-wrap text-break">
-                      <BsStarFill title="Original" className="star-icon mr-4" />
-                      This pack has been created exclusively for Signal by the artist, from original artworks.
-                    </li>
-                  : null
-                }
-
-                {/* Animated */}
-                {stickerPack.meta.animated
-                  ? <li className="list-group-item text-wrap text-break">
-                      <BsFillCameraVideoFill title="Animated" className="text-primary mr-4" />
-                      This pack contains animated stickers!
-                    </li>
-                  : null
-                }
-
-                {/* Source */}
-                {stickerPack.meta.source
-                  ? <li className="list-group-item text-wrap text-break">
-                      <BsAt title="Source" className="mr-4 text-primary mention-icon" />
-                      <div>
-                        <Linkify componentDecorator={linkifyHrefDecorator}>
-                          {stickerPack.meta.source}
-                        </Linkify>
-                      </div>
-                    </li>
-                  : null
-                }
-
-                {/* Sticker Count */}
+              {/* Original */}
+              {stickerPack.meta.original &&
                 <li className="list-group-item text-wrap text-break">
-                  <BsFolder title="Sticker Count" className="mr-4 text-primary" />
-                  {stickerPack.manifest.stickers.length}
+                  <BsStarFill title="Original" className="star-icon mr-4" />
+                  This pack has been created exclusively for Signal by the artist, from original artworks.
                 </li>
+              }
 
-                {/* Tags */}
-                <li className="list-group-item">
-                  <BsTag title="Tags" className="mr-4 text-primary" />
-                  <div className="text-wrap text-break mb-n1">
-                    {stickerPack.meta.tags && stickerPack.meta.tags.length > 0 ? stickerPack.meta.tags.map(tag => (
-                      <Tag key={tag} className="mb-1 mr-1" label={tag} />
-                    )) : 'None'}
+              {/* Animated */}
+              {stickerPack.meta.animated &&
+                <li className="list-group-item text-wrap text-break">
+                  <BsFillCameraVideoFill title="Animated" className="text-primary mr-4" />
+                  This pack contains animated stickers!
+                </li>
+              }
+
+              {/* Source */}
+              {stickerPack.meta.source &&
+                <li className="list-group-item text-wrap text-break">
+                  <BsAt title="Source" className="mr-4 text-primary mention-icon" />
+                  <div>
+                    <Linkify componentDecorator={linkifyHrefDecorator}>
+                      {stickerPack.meta.source}
+                    </Linkify>
                   </div>
                 </li>
-              </ul>
-            </div>
+              }
+
+              {/* Sticker Count */}
+              <li className="list-group-item text-wrap text-break">
+                <BsFolder title="Sticker Count" className="mr-4 text-primary" />
+                {stickerPack.manifest.stickers.length}
+              </li>
+
+              {/* Tags */}
+              <li className="list-group-item">
+                <BsTag title="Tags" className="mr-4 text-primary" />
+                <div className="text-wrap text-break mb-n1">
+                  {stickerPack.meta.tags && stickerPack.meta.tags.length > 0 ? stickerPack.meta.tags.map(tag => (
+                    <Tag key={tag} className="mb-1 mr-1" label={tag} />
+                  )) : 'None'}
+                </div>
+              </li>
+            </ul>
           </div>
+        </div>
       }
 
       {/* Stickers */}

--- a/src/contexts/AppStateContext.tsx
+++ b/src/contexts/AppStateContext.tsx
@@ -1,0 +1,99 @@
+import * as R from 'ramda';
+import React from 'react';
+
+
+// ----- Types -----------------------------------------------------------------
+
+/**
+ * Type of the value provided by this Context: a custom hook function that
+ * accepts a key and returns tuple with a value of type T and a setValue
+ * function that accepts a value of type T.
+ */
+export type AppStateContext = <T = any>(key: string) => [
+  T | undefined,
+  React.Dispatch<React.SetStateAction<T>>
+];
+
+
+/**
+ * The context's state is a map that mirrors key/value pairs in Local Storage.
+ * We keep this in-memory mapping to avoid having to read from Local Storage on
+ * each re-render.
+ */
+interface State {
+  [index: string]: any;
+}
+
+
+/**
+ * Action type for our reducer.
+ */
+interface SetStateAction {
+  key: string;
+  value: any;
+}
+
+
+// ----- Initial State ---------------------------------------------------------
+
+const initialState: State = {
+  darkMode: false
+};
+
+
+// ----- Context ---------------------------------------------------------------
+
+const Context = React.createContext<AppStateContext>({} as any);
+
+
+export const Provider = (props: React.PropsWithChildren<Record<string, unknown>>) => {
+  /**
+   * Initializes app state by iterating over each key in our initial state
+   * object and fetching the corresponding value from Local Storage.
+   */
+  const initializer = (initialState: State): State => {
+    return R.mapObjIndexed((initialValue, key) => {
+      try {
+        return JSON.parse(localStorage.getItem(key) ?? initialValue);
+      } catch {
+        // Local storage may be unavailable. Return the initial value.
+        return initialValue;
+      }
+    }, initialState);
+  };
+
+  /**
+   * Handles state updates by setting values in Local Storage.
+   */
+  const reducer = (state: State, action: SetStateAction): State => {
+    try {
+      localStorage.setItem(String(action.key), JSON.stringify(action.value));
+    } catch {
+      // Local storage may not be available due to private mode, etc.
+    }
+
+    return {...state, [action.key]: action.value};
+  };
+
+  const [state, dispatch] = React.useReducer(reducer, initialState, initializer);
+
+  // N.B. There seems to be a parsing error with TSX + arrow functions that use
+  // generic type parameters. Re-visit in the future.
+  // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+  function useAppState<T = any>(key: string) {
+    const setState: React.Dispatch<React.SetStateAction<T>> = (value: React.SetStateAction<T>) => {
+      dispatch({key, value});
+    };
+
+    return [state[key], setState] as any;
+  }
+
+  return (
+    <Context.Provider value={useAppState}>
+      {props.children}
+    </Context.Provider>
+  );
+};
+
+
+export default Context;

--- a/src/etc/colors.ts
+++ b/src/etc/colors.ts
@@ -1,0 +1,45 @@
+import {darken, lighten, saturate} from 'polished';
+
+
+/**
+ * Saturated version of Bootstrap's --danger color.
+ */
+export const DANGER_SATURATED = saturate(0.2, '#DC3545');
+
+
+/**
+ * Darker version of Bootstrap's --gray color.
+ */
+export const GRAY_DARKER = darken(0.1, '#6C757D');
+
+
+/**
+ * (Even) darker version of Bootstrap's --gray color.
+ */
+export const GRAY_DARKER_2 = darken(0.255, '#6C757D');
+
+
+/**
+ * Lighter version of Bootstrap's --gray color.
+ */
+export const GRAY_LIGHTER = lighten(0.18, '#6C757D');
+
+
+/**
+ * Darker version of Bootstrap's --primary color.
+ */
+export const PRIMARY_DARKER = darken(0.15, '#007BFF');
+
+
+/**
+ * Lighter version of Bootstrap's --primary color.
+ */
+export const PRIMARY_LIGHTER = lighten(0.2, '#007BFF');
+
+
+/**
+ * Darker version of Bootstrap's --gray-dark color.
+ *
+ * Used as the background color for primary content containers in dark mode.
+ */
+export const DARK_THEME_BACKGROUND = darken(0.01, '#343A40');

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,6 @@ html {
 }
 
 body {
-  background-color: var(--primary);
   font-family: Montserrat, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -32,7 +31,6 @@ a {
 }
 
 #root {
-  background-color: white;
   display: flex;
   flex-direction: column;
   min-height: calc(100vh - env(safe-area-inset-top, 0px));

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -174,7 +174,7 @@ export default function SearchFactory<T>(options: SearchFactoryOptions<T>): Sear
       case 'Undefined':
         return 'false';
       default:
-        throw new Error(`[Search::getFn] Unable to parse value of type "${valueType}" at path "${path}".`);
+        throw new Error(`[Search::getFn] Unable to parse value of type "${valueType}" at path "${String(path)}".`);
     }
   };
 

--- a/src/lib/stickers.ts
+++ b/src/lib/stickers.ts
@@ -25,6 +25,7 @@ import {
 } from 'etc/types';
 import {convertImage} from 'lib/convert-image';
 import ErrorWithCode from 'lib/error';
+import {isStorageUnavailableError} from 'lib/utils';
 
 
 // ----- Locals ----------------------------------------------------------------
@@ -57,26 +58,6 @@ const stickerImageCache = LocalForage.createInstance({
 
 
 // ----- Functions -------------------------------------------------------------
-
-/**
- * [private]
- *
- * Returns true if the provided error was thrown because the browser is blocking
- * use of local storage and/or other storage back-ends.
- */
-function isStorageUnavailableError(err: any) {
-  const patterns = [
-    // Firefox in private mode.
-    /the quota has been exceeded/gi
-  ];
-
-  if (err?.message) {
-    return Boolean(R.find(curPattern => R.test(curPattern, err.message), patterns));
-  }
-
-  return false;
-}
-
 
 /**
  * Resolves with a list of StickerPackPartial objects.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,6 @@
 import bytes from 'bytes';
+import * as R from 'ramda';
+
 import {BOOTSTRAP_BREAKPOINTS} from 'etc/constants';
 
 
@@ -62,4 +64,22 @@ export function sendBeacon() {
       console.log(`${err}. No worries, it's okay!`);
     }
   }
+}
+
+
+/**
+ * Returns true if the provided error was thrown because the browser is blocking
+ * use of local storage and/or other storage back-ends.
+ */
+export function isStorageUnavailableError(err: any) {
+  const patterns = [
+    // Firefox in private mode.
+    /the quota has been exceeded/gi
+  ];
+
+  if (err?.message) {
+    return Boolean(R.find(curPattern => R.test(curPattern, err.message), patterns));
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Add Dark Mode 🧛🏻‍♂️

Signal Stickers gets dark mode!

<img width="1168" alt="Screen Shot 2020-08-12 at 3 09 53 AM" src="https://user-images.githubusercontent.com/441546/90003759-65fca180-dc49-11ea-9456-da42c6235b56.png">

#### Summary of Changes

* Added a new context, `AppStateContext`, which exposes a hook `useAppState`. This hook can be used to get/set values that will be backed by local storage (when available) and thus persisted across page refreshes.

   ```ts
   const [foo, setFoo] = useAppState('foo')
   ```

* Refactored some of the base app layout code into a new component, `AppLayout`.
* The above two updates provided support for: Dark Mode!
  * Where possible, all color values rely on CSS variables provided by Bootstrap. This helps us ensure that colors remain properly balanced and reduces the amount of thinking we have to do around theme development, which is surprisingly non-trivial.
  * Where it was necessary to deviate from Bootstrap's colors (or modify them) these colors have been variable-ized and documented.
* Did some more refactoring on the search input component to make it easier to theme and generally more coherent. This involved dropping the use of Bootstrap's `input-append` and `input-prepend` elements in favor of embedding custom elements into a single container element. Also added some subtle hover/active animation to the clear button.
* Added logic in the new `AppLayout` component to dynamically swap the background color of the `<body>` element to match either the navbar background or the content container's background so that when a user over-scrolls (typically on a mobile device) the over-scroll color will match the navbar (if over-scrolling upwards) or the content container (if over-scrolling downwards). ✨