### PR TITLE
Adding Garfield Letters + Tux Paint Stamps 1 & 2

### DIFF
--- a/stickers.yml
+++ b/stickers.yml
@@ -21464,7 +21464,7 @@ b3ae78d46e2eb9f23febc7b1a00b1f8b:
   original: false
 afbfbb1658b55784f7402b1a0e634ad4:
   key: 4e2394cfbf70d87ae1e1687ed97e1b1cd35aed7f856ee9d2cc25504279d11289
-  source: 'Part 2: https://signalstickers.com/pack/09cf7581ffe8e34c3992018e50fcabe3?key=8138fdc1c0bbb35d4b34f4243c39cfabeda0bf83d905e63dac81de9bad38978b'
+  source: ''
   tags:
     - linux
     - gnu
@@ -21484,7 +21484,7 @@ afbfbb1658b55784f7402b1a0e634ad4:
   original: false
 09cf7581ffe8e34c3992018e50fcabe3:
   key: 8138fdc1c0bbb35d4b34f4243c39cfabeda0bf83d905e63dac81de9bad38978b
-  source: 'Part 1: https://signalstickers.com/pack/afbfbb1658b55784f7402b1a0e634ad4?key=4e2394cfbf70d87ae1e1687ed97e1b1cd35aed7f856ee9d2cc25504279d11289'
+  source: ''
   tags:
     - linux
     - gnu

--- a/stickers.yml
+++ b/stickers.yml
@@ -21447,3 +21447,58 @@ b3ae78d46e2eb9f23febc7b1a00b1f8b:
     - cute
   nsfw: false
   original: false
+6ed54c8a448a48fd8ed475ad578755e8:
+  key: 2b38829c094b464711e90bffb4abf113a2236eaaa8333007e750da466e2a5937
+  source: ''
+  tags:
+    - garfield
+    - cat
+    - cartoon
+    - jim davis
+    - lasagna
+    - meme
+    - cute
+    - letters
+    - alphabet
+  nsfw: false
+  original: false
+afbfbb1658b55784f7402b1a0e634ad4:
+  key: 4e2394cfbf70d87ae1e1687ed97e1b1cd35aed7f856ee9d2cc25504279d11289
+  source: 'Part 2: https://signalstickers.com/pack/09cf7581ffe8e34c3992018e50fcabe3?key=8138fdc1c0bbb35d4b34f4243c39cfabeda0bf83d905e63dac81de9bad38978b'
+  tags:
+    - linux
+    - gnu
+    - gnulinux
+    - gnu linux
+    - gnu plus linux
+    - gnu slash linux tux
+    - privacy
+    - cute
+    - for children
+    - tux paint
+    - paint
+    - stamps
+    - free software
+    - libre software
+  nsfw: false
+  original: false
+09cf7581ffe8e34c3992018e50fcabe3:
+  key: 8138fdc1c0bbb35d4b34f4243c39cfabeda0bf83d905e63dac81de9bad38978b
+  source: 'Part 1: https://signalstickers.com/pack/afbfbb1658b55784f7402b1a0e634ad4?key=4e2394cfbf70d87ae1e1687ed97e1b1cd35aed7f856ee9d2cc25504279d11289'
+  tags:
+    - linux
+    - gnu
+    - gnulinux
+    - gnu linux
+    - gnu plus linux
+    - gnu slash linux tux
+    - privacy
+    - cute
+    - for children
+    - tux paint
+    - paint
+    - stamps
+    - free software
+    - libre software
+  nsfw: false
+  original: false


### PR DESCRIPTION
Garfield Letters is just some Garfield Letters I found on Twitter (which i couldn't find the source of no matter how hard i looked)
Tux Paint Stamps is literally all the stamps from Tux Paint (including the optional stamps collection) and nobody asked for or wants it but I did it


Garfield Letters: https://signalstickers.com/pack/6ed54c8a448a48fd8ed475ad578755e8?key=2b38829c094b464711e90bffb4abf113a2236eaaa8333007e750da466e2a5937

Tux Paint 1: https://signalstickers.com/pack/afbfbb1658b55784f7402b1a0e634ad4?key=4e2394cfbf70d87ae1e1687ed97e1b1cd35aed7f856ee9d2cc25504279d11289
Tux Paint 2: https://signalstickers.com/pack/09cf7581ffe8e34c3992018e50fcabe3?key=8138fdc1c0bbb35d4b34f4243c39cfabeda0bf83d905e63dac81de9bad38978b