### PR TITLE
chore: Add preload-webpack-plugin.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,5 +9,8 @@ module.exports = {
   ],
   plugins: [
     'react-hot-loader/babel'
-  ]
+  ],
+  // Ensures Webpack comments are not prematurely removed by Babel. Comments
+  // will still be stripped by the minifier in production builds.
+  comments: true
 };

--- a/config/webpack.config.babel.ts
+++ b/config/webpack.config.babel.ts
@@ -7,6 +7,8 @@ import FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 import FriendlyErrorsWebpackPlugin from 'friendly-errors-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+// @ts-expect-error No declarations exist for this plugin.
+import PreloadWebpackPlugin from 'preload-webpack-plugin';
 import * as R from 'ramda';
 import webpack from 'webpack';
 import { FaviconWebpackPlugionOptions } from 'favicons-webpack-plugin/src/options';
@@ -231,8 +233,14 @@ export default (env: string, argv: any): webpack.Configuration => {
     inject: true
   }));
 
+  // Add resource hints to preload assets used in the initial chunk. This plugin
+  // must be added after html-webpack-plugin.
+  config.plugins.push(new PreloadWebpackPlugin({
+    include: ['home']
+  }));
+
   config.plugins.push(new MiniCssExtractPlugin({
-    filename: argv.mode === 'production' ? 'styles-[contenthash].css' : 'styles.css'
+    filename: argv.mode === 'production' ? '[name]-[contenthash].css' : 'styles.css'
   }));
 
   config.plugins.push(new webpack.LoaderOptionsPlugin({

--- a/package-lock.json
+++ b/package-lock.json
@@ -19505,6 +19505,24 @@
         "starts-with": "^1.0.2"
       }
     },
+    "preload-webpack-plugin": {
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/preload-webpack-plugin/-/preload-webpack-plugin-3.0.0-beta.3.tgz",
+      "integrity": "sha512-pIRna/JagOd+ci64d84SfDH4bjKsM632OQ/4JIBk7Q8Kr6VH2X+7q5q3HrTilKpMzzO3ib9kC7rs1B0KXJTa6Q==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "json-loader": "^0.5.7",
     "mini-css-extract-plugin": "^0.9.0",
     "modernizr-loader": "^1.0.1",
+    "preload-webpack-plugin": "^3.0.0-beta.3",
     "raw-loader": "^4.0.1",
     "react-hot-loader": "^4.12.21",
     "style-loader": "^1.2.1",

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -21,10 +21,25 @@ import {
 
 
 // Note: Each top-level route should be imported az a lazy-loaded component.
-const About = React.lazy(async () => import('components/about/About'));
-const Contribute = React.lazy(async () => import('components/contribute/Contribute'));
-const Home = React.lazy(async () => import('components/home/Home'));
-const Pack = React.lazy(async () => import('components/pack/StickerPackDetail'));
+const Home = React.lazy(async () => import(
+  /* webpackChunkName: "home" */
+  'components/home/Home'
+));
+
+const Pack = React.lazy(async () => import(
+  /* webpackChunkName: "detail" */
+  'components/pack/StickerPackDetail'
+));
+
+const Contribute = React.lazy(async () => import(
+  /* webpackChunkName: "contribute" */
+  'components/contribute/Contribute'
+));
+
+const About = React.lazy(async () => import(
+  /* webpackChunkName: "about" */
+  'components/about/About'
+));
 
 
 // ----- Styles ----------------------------------------------------------------

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
     <meta name="twitter:site" content="@signalstickers" />
     <meta property="og:description" content="Community-organized gallery of sticker packs for Signal. Browse more than 1500 stickers, and propose your own!" />
     <meta property="og:image" content="https://raw.githubusercontent.com/signalstickers/signalstickers/master/src/assets/favicon.png" />
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700&display=block" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700" crossorigin="anonymous"  />
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
@@ -44,6 +44,10 @@
       }(window.location))
     </script>
     <!-- End Single Page Apps for GitHub Pages -->
+
+    <!-- Resource Hints -->
+    <link rel="preconnect" href="https://cdn-ca.signal.org" crossorigin="anonymous" />
+    <link rel="preconnect" href="https://ping.signalstickers.com" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Add `preload-webpack-plugin`

After performing a [Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of signalstickers.com, I discovered we could improve our initial page load time a bit by adding [resource hints](https://www.smashingmagazine.com/2019/04/optimization-performance-resource-hints/).

#### Summary of Changes

* Update Babel config and dynamic imports to support named chunks.
* Add [`preload-webpack-plugin`](https://github.com/GoogleChromeLabs/preload-webpack-plugin), which injects resource hints into `index.html` to preload assets in the `home` chunk.
* Add additional `preconnect` hints for `ping.signalstickers.com` and the Signal CDN.