### PR TITLE
Add WhatsApp, Facebook, Tonton, Quan tags to some sticker packs

### DIFF
--- a/stickers.yml
+++ b/stickers.yml
@@ -620,17 +620,23 @@ ce9d395268e045b6ee96a53bdc8c62f1:
 aa6edcc941b9c9043dea44eaf667801b:
   key: 8f0ed5150bebd1c6b9e72c8f07aec93650fb476201d338479bdfdf0af16545a3
   source: ''
-  tags: []
+  tags:
+    - WhatsApp
+    - cute
   nsfw: false
 97fbc9f4692a4b317d4cc19e8cb535b9:
   key: da9e676f0d319fd3a0f155f009aacd4fc093bc0f975e5ac60604a8a664e21376
   source: ''
-  tags: []
+  tags:
+    - WhatsApp
+    - cute
   nsfw: false
 78d7712a1dd6ba801b0124657aaadc44:
   key: 858d901e3ed4b257e108c86ce7763b6268108d47f4a035796edcc3eec798ef3b
   source: ''
-  tags: []
+  tags:
+    - WhatsApp
+    - cute
   nsfw: false
 2484682209b6f89272aa6bd84e494c90:
   key: a1bf18d3763e22e062d0bd7b590bbe0f7e4d7e808e45ebe91f765dcdc0c7789e
@@ -10320,6 +10326,7 @@ c5fb525dfd1fcfa33dc3464434c17481:
     - animals
     - Shiba Inu
     - telegram
+    - WhatsApp
   nsfw: false
 92913b5096ae2eaf00e48bc4da0779fe:
   key: 95915416dcf28b0c227fdb2adbb45c7e4b60f36485eec7067ecc2f64cb074c1f
@@ -14046,6 +14053,7 @@ bade6321eeffc151c4a096a42addfcbd:
     - bears
     - Opi (by Óscar Ospina)
     - telegram
+    - WhatsApp
   nsfw: false
 3511934c77d1af7dfef2cb28686a3279:
   key: 8022b9f229b7bacaf5c509dda5ac4b2a646b9ed1352ce064aa0a25e4857fa93a
@@ -18424,6 +18432,7 @@ c4d50001e190c19f1d7aabc1b83e4041:
   key: 1320504bedc7a334527bc3ba6609b2732132723db96e00ff68976b8f39bdf6ba
   source: WhatsApp
   tags:
+    - WhatsApp
     - Hatch
     - pet
   nsfw: false
@@ -19727,6 +19736,7 @@ f08641daea2483a0850edb953c050d6c:
   key: 5ac72235e31bf89cbdd96db160e499f62f6481aff595ebb7cbce86306071142d
   source: WhatsApp
   tags:
+    - WhatsApp
     - French
     - COVID_19
     - COVID-19
@@ -19742,6 +19752,7 @@ cb174d964d148270acd76f6fd0f88bae:
     WhatsApp (via
     https://community.signalusers.org/t/sticker-pack-collection-thread-makeprivacystick/10650/276)
   tags:
+    - WhatsApp
     - COVID_19
     - COVID-19
     - coronavirus
@@ -21446,6 +21457,8 @@ b3ae78d46e2eb9f23febc7b1a00b1f8b:
   key: c639c5afadced689c865740c1a3124fb0ad23599472e3c25b4022586a1332f20
   source: signalstickers.com
   tags:
+    - WhatsApp
+    - Facebook
     - cute
   nsfw: false
   original: false
@@ -21581,6 +21594,7 @@ ea5512d7c817aa25219b72510f537529:
   key: e891105ac845afd33bd593dfd436eff9f337db8c3f9626e30ba61413e2c1678a
   source: signalstickers.com
   tags:
+    - WhatsApp
     - piyomaru
     - cute
     - for children

--- a/stickers.yml
+++ b/stickers.yml
@@ -110,7 +110,10 @@ ae1d343accdec586fe19954a6be7aee9:
 6fd767372b7b82b4aba4f0f034936311:
   key: ecb8392df60fc0719df33160f124bf0f9b0a2857397cabcc461a6db77fd678f2
   source: ''
-  tags: []
+  tags:
+    - Quan Inc
+    - cute
+    - Facebook
   nsfw: false
 cbc0261b03b764bc31b73118bce2905b:
   key: f5ff52bd727e840986a1586094394d3062d8aea4c33976eb51001c1b025d2814
@@ -621,21 +624,27 @@ aa6edcc941b9c9043dea44eaf667801b:
   key: 8f0ed5150bebd1c6b9e72c8f07aec93650fb476201d338479bdfdf0af16545a3
   source: ''
   tags:
+    - Tonton
     - WhatsApp
+    - Facebook
     - cute
   nsfw: false
 97fbc9f4692a4b317d4cc19e8cb535b9:
   key: da9e676f0d319fd3a0f155f009aacd4fc093bc0f975e5ac60604a8a664e21376
   source: ''
   tags:
+    - Tonton
     - WhatsApp
+    - Facebook
     - cute
   nsfw: false
 78d7712a1dd6ba801b0124657aaadc44:
   key: 858d901e3ed4b257e108c86ce7763b6268108d47f4a035796edcc3eec798ef3b
   source: ''
   tags:
+    - Tonton
     - WhatsApp
+    - Facebook
     - cute
   nsfw: false
 2484682209b6f89272aa6bd84e494c90:
@@ -14054,6 +14063,7 @@ bade6321eeffc151c4a096a42addfcbd:
     - Opi (by Óscar Ospina)
     - telegram
     - WhatsApp
+    - Facebook
   nsfw: false
 3511934c77d1af7dfef2cb28686a3279:
   key: 8022b9f229b7bacaf5c509dda5ac4b2a646b9ed1352ce064aa0a25e4857fa93a
@@ -18433,6 +18443,7 @@ c4d50001e190c19f1d7aabc1b83e4041:
   source: WhatsApp
   tags:
     - WhatsApp
+    - Facebook
     - Hatch
     - pet
   nsfw: false
@@ -21588,6 +21599,7 @@ ea5512d7c817aa25219b72510f537529:
   tags:
     - Quan Inc
     - 'ビジネスフィッシュ'
+    - Facebook
   nsfw: false
   original: false
 085dd0ddcac423a7be5807bf42301349:
@@ -21600,6 +21612,7 @@ ea5512d7c817aa25219b72510f537529:
     - for children
     - 'ぴよまる'
     - Quan Inc
+    - Facebook
   nsfw: false
   original: false
   animated: true


### PR DESCRIPTION
This PR adds WhatsApp, Facebook, Tonton, and Quan Inc tags to some sticker packs that are also found on WhatsApp and Facebook by default. This makes it easier for migrating users to find the packs they are looking for.