### PR TITLE
chore: Update CI configuration.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI/CD
 on:
   - push
-  - pull_request
 jobs:
   build-test:
     name: Build & Test


### PR DESCRIPTION
Removing the `pull_request` trigger for CI jobs, as PR branches are already built via the `push` trigger, so this was resulting in redundant jobs.