### PR TITLE
fix: Search query param is removed from URL when empty.

### DIFF
--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -48,11 +48,14 @@ const HomeComponent: React.FunctionComponent = () => {
    * Perform a state-to-URL sync when the search query changes.
    */
   React.useEffect(() => {
+    console.debug('Sticking this search query into the URL:', searchQuery);
+    console.debug('Type:', typeof searchQuery);
+
     updateUrl({
       query: {
         // Coerce empty strings to null to cause the query param to be
         // removed from the URL when the search query is cleared.
-        [SEARCH_QUERY_PARAM]: searchQuery || null
+        [SEARCH_QUERY_PARAM]: searchQuery
       }
     });
   }, [searchQuery]);

--- a/src/hooks/use-update-url.ts
+++ b/src/hooks/use-update-url.ts
@@ -1,6 +1,6 @@
-import queryString, {ParsedUrl} from 'query-string';
+import queryString, { ParsedUrl } from 'query-string';
 import * as R from 'ramda';
-import {useHistory} from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 
 /**
@@ -19,7 +19,11 @@ export default function useUpdateUrl() {
 
   return (newValues: Partial<ParsedUrl>) => {
     const currentUrl = queryString.parseUrl(history.location.pathname);
-    const newUrl = queryString.stringifyUrl(R.mergeDeepRight(currentUrl, newValues) as ParsedUrl);
+    const newUrl = queryString.stringifyUrl(R.mergeDeepRight(currentUrl, newValues) as ParsedUrl, {
+      // This ensures that the search query param is removed from the URL when
+      // the search query is cleared.
+      skipEmptyString: true
+    });
     history.replace(newUrl);
   };
 }


### PR DESCRIPTION
## Search Query Param is Removed From URL When Empty

Recently, on initial page load, an empty `s` query param was being added to the URL. The desired/previous behavior was that when the search query was empty, the param should be removed from the URL.

<img width="983" alt="Screen Shot 2021-01-17 at 8 55 36 PM" src="https://user-images.githubusercontent.com/441546/104873880-60953880-5906-11eb-9c3f-60614b635bb9.png">

This bug was likely introduced via a non-breaking upgrade of the `query-string` library which caused empty strings to be added to the URL. Luckily, the library has (or introduced) a `skipEmptyString` option that provides a clean fix for this issue.
