### PR TITLE
feat: Add Dark Theme & "Copy to Clipboard" button to YAML Blob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10062,6 +10062,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "copy-webpack-plugin": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz",
@@ -24418,6 +24426,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@signalstickers/stickers-client": "^1.0.1",
     "axios": "^0.21.1",
     "bytes": "^3.1.0",
+    "copy-to-clipboard": "^3.3.1",
     "core-js": "^3.8.2",
     "debounce-fn": "^4.0.0",
     "formik": "^2.2.6",

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns the string 'light' if the light theme is in use and 'dark' if the
+ * dark theme is in use.
+ */
+export default function useTheme() {
+  const bodyEls = document.querySelectorAll('body');
+
+  if (bodyEls.length > 1) {
+    throw new Error('[useTheme] Found more than 1 <body> element in the DOM.');
+  }
+
+  const bodyEl = bodyEls[0];
+
+  if (bodyEl.classList.contains('theme-light')) {
+    return 'light';
+  }
+
+  if (bodyEl.classList.contains('theme-dark')) {
+    return 'dark';
+  }
+
+  throw new Error('[useTheme] Unknown theme.');
+}


### PR DESCRIPTION
## Add Dark Theme & Copy Button to YAML blob.

Light theme:

<img width="1100" alt="Screen Shot 2021-01-28 at 4 52 30 AM" src="https://user-images.githubusercontent.com/441546/106141332-c793c800-6124-11eb-99d9-3d50c047db28.png">

Dark theme:

<img width="1100" alt="Screen Shot 2021-01-28 at 4 52 36 AM" src="https://user-images.githubusercontent.com/441546/106141330-c6629b00-6124-11eb-9495-001301d1d213.png">

---

### Rationale

I'm noticing that PRs that include a trailing newline after the YAML blob tend to trigger fewer merge conflicts than those that do not. This is a way to test that hypothesis by adding a "Copy to Clipboard" button that will ensure the text the user 🍜 's into the file in GitHub will contain that empty newline. Hopefully, this will cause merge conflicts with the base branch to decrease, allowing us to merge Pull Requests much more quickly.

